### PR TITLE
Preprocess skipper

### DIFF
--- a/libs/preprocess/preprocess.py
+++ b/libs/preprocess/preprocess.py
@@ -543,6 +543,15 @@ class Preprocessor:
             print(error)
             return False
         
+        # set process version number
+        ppversion = 0.1
+        # short-circuit and skip if JSON already process version
+        try:
+            if doc.manifest_dict['ppversion'] == ppversion:
+                return True
+        except KeyError:
+            doc.manifest_dict['ppversion'] = ppversion
+        
         # export the wikifier document if the directory is set
         if self.wikifier_output_dir:
             doc.export_content(output_dir=self.wikifier_output_dir)

--- a/libs/preprocess/preprocess.py
+++ b/libs/preprocess/preprocess.py
@@ -530,8 +530,9 @@ class Preprocessor:
         """
         self.preprocess(manifest_dir, filename, content_property, kwargs)
     
-    def preprocess(self, manifest_dir, filename, content_property, kwargs=None, add_properties=None, remove_properties=None):
+    def preprocess(self, manifest_dir, filename, content_property, kwargs=None, add_properties=None, remove_properties=None, ppversion='0.1'):
         """Start the main preprocessing function."""
+
         # Start doc timer
         doc_start = time.time()
     
@@ -543,9 +544,7 @@ class Preprocessor:
             print(error)
             return False
         
-        # set process version number
-        ppversion = 0.1
-        # short-circuit and skip if JSON already process version
+        # short-circuit and skip if JSON was already processed by version
         try:
             if doc.manifest_dict['ppversion'] == ppversion:
                 return True


### PR DESCRIPTION
Scott, because this is stored in the JSON manifest I think you should review this proposal:

In order to massively speed up batch reruns:

1. the preprocessor has a version number, e.g. ppversion="0.1"
2. if that exact version number is found in the JSON, it skips handling the file entirely and moves on to the next document.
3. if it is not, it writes the version number into the JSON before processing the file.

Because this happens before any spacy processing, it means files can be skipped as soon as they are loaded, speeding up partial reruns, renamed or modified / sampled zips, etc.

When we bump the preprocessing process, we bump the number. This can be done through the method arguments, but should generally be done when the code is checked in.